### PR TITLE
Time Debug impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ derive_more = "0.99.17"
 lazy_static = "1.4.0"
 regex = "1.7.1"
 serde = { version = "1.0.152", features = ["derive"], default-features = false }
+thiserror = "1.0.50"
 
 [dev-dependencies]
 serde_test = "1.0.152"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,11 +330,7 @@ pub enum TimeWindowError {
 impl Debug for Time {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let positive = self.0 >= 0;
-        let mut total = if self.0 == i64::MIN {
-            9223372036854775808usize
-        } else {
-            self.0.abs() as usize
-        };
+        let mut total = self.0.unsigned_abs();
         let millis_part = total % 1000;
         total -= millis_part;
         let seconds_part = (total % (1000 * 60)) / 1000;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,6 +329,9 @@ pub enum TimeWindowError {
 
 impl Debug for Time {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        // This implementation is tailor-made, because NaiveDateTime does not support
+        // the full range of Time. For some Time instances it wouldn't be
+        // possible to reconstruct them based on the Debug-representation ('∞').
         let positive = self.0 >= 0;
         let mut total = self.0.unsigned_abs();
         let millis_part = total % 1000;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ use regex::Regex;
 use serde::de::Visitor;
 use serde::Deserialize;
 use serde::Serialize;
+use thiserror::Error;
 
 /// A point in time.
 ///
@@ -339,7 +340,7 @@ impl Debug for Time {
         write!(f, "{:02}:", minutes_part)?;
         write!(f, "{:02}", seconds_part)?;
         if millis_part > 0 {
-            write!(f, ".{}", millis_part)?;
+            write!(f, ".{:03}", millis_part)?;
         }
         Ok(())
     }
@@ -1433,6 +1434,11 @@ mod time_test {
                 name: "i64::MIN",
                 input: Time::millis(i64::MIN),
                 expected: "-2562047788015:12:55.808".to_string(),
+            },
+            TestCase {
+                name: "millis",
+                input: Time::hours(3) + Duration::millis(42),
+                expected: "03:00:00.042".to_string(),
             },
         ];
         for test in tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,9 @@ use std::cmp::max;
 use std::cmp::min;
 use std::cmp::Ordering;
 use std::error::Error;
-use std::fmt::{Debug, Formatter};
+use std::fmt::Debug;
 use std::fmt::Display;
+use std::fmt::Formatter;
 use std::ops::Add;
 use std::ops::AddAssign;
 use std::ops::Div;
@@ -74,7 +75,7 @@ use thiserror::Error;
 ///
 /// Low overhead time representation. Internally represented as milliseconds.
 #[derive(
-Eq, PartialEq, Hash, Ord, PartialOrd, Copy, Clone, Default, Serialize, Deref, From, Into,
+    Eq, PartialEq, Hash, Ord, PartialOrd, Copy, Clone, Default, Serialize, Deref, From, Into,
 )]
 pub struct Time(i64);
 
@@ -134,7 +135,7 @@ impl Time {
         // casting to u32 is safe here because it is guaranteed that the value is in
         // 0..1_000_000_000
         #[allow(clippy::cast_possible_truncation)]
-            let nanos = if nanos.is_negative() {
+        let nanos = if nanos.is_negative() {
             1_000_000_000 - nanos.unsigned_abs()
         } else {
             nanos.unsigned_abs()
@@ -265,8 +266,8 @@ impl Display for Time {
 /// Allows deserializing from RFC 3339 strings and unsigned integers.
 impl<'de> Deserialize<'de> for Time {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: serde::Deserializer<'de>,
+    where
+        D: serde::Deserializer<'de>,
     {
         deserializer.deserialize_any(TimeVisitor)
     }
@@ -282,15 +283,15 @@ impl<'de> Visitor<'de> for TimeVisitor {
     }
 
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         Time::parse_from_rfc3339(v).map_err(|e| E::custom(e.to_string()))
     }
 
     fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         i64::try_from(v)
             .map_err(|e| E::custom(e.to_string()))
@@ -298,8 +299,8 @@ impl<'de> Visitor<'de> for TimeVisitor {
     }
 
     fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-        where
-            D: serde::Deserializer<'de>,
+    where
+        D: serde::Deserializer<'de>,
     {
         // expecting an unsigned integer inside the newtype struct, but technically also
         // allowing strings
@@ -804,21 +805,21 @@ impl TimeWindow {
 /// Duration can be negative. Internally duration is represented as
 /// milliseconds.
 #[derive(
-Eq,
-PartialEq,
-Ord,
-PartialOrd,
-Copy,
-Clone,
-Debug,
-Default,
-Hash,
-Serialize,
-Deref,
-From,
-Into,
-Sum,
-Neg,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Hash,
+    Serialize,
+    Deref,
+    From,
+    Into,
+    Sum,
+    Neg,
 )]
 pub struct Duration(i64);
 
@@ -904,8 +905,8 @@ impl Duration {
 /// Allows deserializing from strings, unsigned integers, and signed integers.
 impl<'de> Deserialize<'de> for Duration {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: serde::Deserializer<'de>,
+    where
+        D: serde::Deserializer<'de>,
     {
         deserializer.deserialize_any(DurationVisitor)
     }
@@ -935,15 +936,15 @@ impl<'de> Visitor<'de> for DurationVisitor {
     }
 
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         Duration::from_str(v).map_err(|e| E::custom(e.to_string()))
     }
 
     fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         i64::try_from(v)
             .map_err(|e| E::custom(e.to_string()))
@@ -951,15 +952,15 @@ impl<'de> Visitor<'de> for DurationVisitor {
     }
 
     fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         Ok(Duration::millis(v))
     }
 
     fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-        where
-            D: serde::Deserializer<'de>,
+    where
+        D: serde::Deserializer<'de>,
     {
         // expecting a signed integer inside the newtype struct, but technically also
         // allowing strings and signed integers
@@ -1256,11 +1257,11 @@ impl From<Duration> for std::time::Duration {
             "Negative Duration {input} cannot be converted to std::time::Duration"
         );
         #[allow(clippy::cast_sign_loss)] // caught by the debug_assert above
-            let secs = (input.0 / 1000) as u64;
+        let secs = (input.0 / 1000) as u64;
         // casting to u32 is safe here because it is guaranteed that the value is in
         // 0..1_000_000_000. The sign loss is caught by the debug_assert above.
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-            let nanos = ((input.0 % 1000) * 1_000_000) as u32;
+        let nanos = ((input.0 % 1000) * 1_000_000) as u32;
         std::time::Duration::new(secs, nanos)
     }
 }
@@ -1565,7 +1566,7 @@ mod duration_test {
                 + Duration::minutes(3)
                 + Duration::seconds(4)
                 + Duration::millis(5))
-                .to_string()
+            .to_string()
         );
 
         assert_eq!("0ms", Duration::ZERO.to_string());


### PR DESCRIPTION
prints Time differently when Debugging:

Before --> After
```
println("{:?}", some_time);
> Time(2700000) -> 00:45:00
> Time(-4351) -> -00:00:04.351
> Time(2147483647) -> 596:31:23.647
```

It would help me to have this representation while debugging. Also it doesn't drop any information (I was considering to use the Display impl instead, but it doesn't work for very large numbers, so that's a deal-breaker)