### PR TITLE
Fix semver

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -43,11 +43,23 @@ jobs:
       pull-requests: read
     steps:
       - uses: actions/checkout@v4
+      # Manually extract labels because rymndhng/release-on-push-action can't do this correctly on a PR
+      - name: Extract labels
+        id: extract_version_bump
+        shell: bash
+        run: |
+          if [ ${{contains( github.event.pull_request.labels.*.name, 'release:major')}} ]; then
+            echo "bump_version=major" >> $GITHUB_OUTPUT
+          elif [ ${{contains( github.event.pull_request.labels.*.name, 'release:minor')}} ]; then
+            echo "bump_version=minor" >> $GITHUB_OUTPUT
+          else
+            echo "bump_version=patch" >> $GITHUB_OUTPUT
+          fi
       - name: Calculate next version
         id: calc_version
         uses: rymndhng/release-on-push-action@master
         with:
-          bump_version_scheme: patch
+          bump_version_scheme: ${{ steps.extract_version_bump.outputs.bump_version }}
           tag_prefix: ""
           dry_run: true
         env:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -48,11 +48,11 @@ jobs:
         id: extract_version_bump
         shell: bash
         run: |
-          if [ ${{contains( github.event.pull_request.labels.*.name, 'release:major')}} ]; then
+          if [ ${{contains( github.event.pull_request.labels.*.name, 'release:major')}} = true ]; then
             echo "bump_version=major" >> $GITHUB_OUTPUT
-          elif [ ${{contains( github.event.pull_request.labels.*.name, 'release:minor')}} ]; then
+          elif [ ${{contains( github.event.pull_request.labels.*.name, 'release:minor')}} = true ]; then
             echo "bump_version=minor" >> $GITHUB_OUTPUT
-          elif [ ${{contains( github.event.pull_request.labels.*.name, 'norelease')}} ]; then
+          elif [ ${{contains( github.event.pull_request.labels.*.name, 'norelease')}} = true ]; then
             echo "bump_version=" >> $GITHUB_OUTPUT
           else
             echo "bump_version=patch" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -50,6 +50,8 @@ jobs:
           dry_run: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Print version
+        run: echo "${{steps.calc_version.outputs.version}}"
       - name: Set version
         if: ${{ steps.calc_version.outputs.version }} != ""
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Make lint
         run: make lint
   semver:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     steps:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,7 +53,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Print version
-        run: echo "${{steps.calc_version.outputs.version}} ${{github.event.pull_request.labels}}"
+        run: | 
+          echo "${{steps.calc_version.outputs.version}} ${{github.event.pull_request.labels}}"
+          echo "${{toJson(github.event.pull_request.labels.*.name)}}"
       - name: Set version
         if: ${{ steps.calc_version.outputs.version }} != ""
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -67,6 +67,7 @@ jobs:
       - name: Print version
         run: | 
           echo "${{steps.calc_version.outputs.version}} ${{github.event.pull_request.labels}}"
+          echo "${{ steps.extract_version_bump.outputs.bump_version }}"
           echo "${{toJson(github.event.pull_request.labels.*.name)}}"
       - name: Set version
         if: ${{ steps.calc_version.outputs.version }} != ""

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,6 +39,8 @@ jobs:
         run: make lint
   semver:
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
       - name: Calculate next version

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,7 +53,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Print version
-        run: echo "${{steps.calc_version.outputs.version}}"
+        run: echo "${{steps.calc_version.outputs.version}} ${{github.event.pull_request.labels}}"
       - name: Set version
         if: ${{ steps.calc_version.outputs.version }} != ""
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -52,11 +52,14 @@ jobs:
             echo "bump_version=major" >> $GITHUB_OUTPUT
           elif [ ${{contains( github.event.pull_request.labels.*.name, 'release:minor')}} ]; then
             echo "bump_version=minor" >> $GITHUB_OUTPUT
+          elif [ ${{contains( github.event.pull_request.labels.*.name, 'norelease')}} ]; then
+            echo "bump_version=" >> $GITHUB_OUTPUT
           else
             echo "bump_version=patch" >> $GITHUB_OUTPUT
           fi
       - name: Calculate next version
         id: calc_version
+        if: ${{ steps.extract_version_bump.outputs.bump_version }} != ""
         uses: rymndhng/release-on-push-action@master
         with:
           bump_version_scheme: ${{ steps.extract_version_bump.outputs.bump_version }}
@@ -70,16 +73,17 @@ jobs:
           echo "${{ steps.extract_version_bump.outputs.bump_version }}"
           echo "${{toJson(github.event.pull_request.labels.*.name)}}"
       - name: Set version
-        if: ${{ steps.calc_version.outputs.version }} != ""
+        if: ${{ steps.extract_version_bump.outputs.bump_version }} != ""
         run: |
           sed -i "s/^version = \".*\"$/version = \"${{ steps.calc_version.outputs.version }}\"/" Cargo.toml
       - name: Commit new version to main but don't push
-        if: ${{ steps.calc_version.outputs.version }} != ""
+        if: ${{ steps.extract_version_bump.outputs.bump_version }} != ""
         run: |
           git config --global user.email "rust-maintainers@moiaorg.onmicrosoft.com"
           git config --global user.name "MOIA Rust Maintainers"
           git commit -am "Phantom release ${{ steps.calc_version.outputs.version }} [skip ci]"
       - name: Check semver
+        if: ${{ steps.extract_version_bump.outputs.bump_version }} != ""
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           version-tag-prefix: ''

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -545,7 +545,7 @@ impl TimeWindow {
     /// assert_eq!(Time::seconds(3), x.start());
     /// ```
     #[must_use]
-    pub fn test(&mut self, new_start: Time) -> Option<Duration> {
+    pub fn extend_start(&mut self, new_start: Time) -> Option<Duration> {
         (new_start < self.start).then(|| {
             let diff = self.start - new_start;
             *self = self.with_new_start(new_start);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -545,7 +545,7 @@ impl TimeWindow {
     /// assert_eq!(Time::seconds(3), x.start());
     /// ```
     #[must_use]
-    pub fn extend_start(&mut self, new_start: Time) -> Option<Duration> {
+    pub fn test(&mut self, new_start: Time) -> Option<Duration> {
         (new_start < self.start).then(|| {
             let diff = self.start - new_start;
             *self = self.with_new_start(new_start);


### PR DESCRIPTION
This fixes an issue with the version bumping that didn't correctly read the `release:` labels which caused the semver check to fail on pull requests.