### PR TITLE
Random sampling of `Time` and `Duration`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,14 @@ edition = "2021"
 version = "0.12.2"
 license = "MIT OR Apache-2.0"
 
+[features]
+rand = ["dep:rand"]
+
 [dependencies]
 chrono = "0.4.31"
 derive_more = "0.99.17"
 lazy_static = "1.4.0"
+rand = { version = "0.8.5", optional = true }
 regex = "1.10.2"
 serde = { version = "1.0.193", features = ["derive"], default-features = false }
 thiserror = "1.0.50"
@@ -58,7 +62,7 @@ missing_const_for_fn = "warn"
 ### Pedantic
 pedantic = { level = "warn", priority = -1 }
 missing_errors_doc = "allow" # TODO
-cast_precision_loss = "allow" 
+cast_precision_loss = "allow"
 cast_possible_truncation = "allow"
 cast_lossless = "allow"
 cast_possible_wrap = "allow"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ tools/grcov/$(GRCOV_VERSION)/grcov:
 
 .PHONY: test
 test:
-	cargo test --workspace --all-targets
+	cargo test --workspace --all-targets --all-features
 	cargo test --workspace --doc
 
 lint:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,9 @@
 //! let result: f64 = duration / duration;          // | Duration   | /  | Duration | f64        |
 
 //! ```
+#[cfg(feature = "rand")]
+pub mod rand;
+
 use core::fmt;
 use std::cmp::max;
 use std::cmp::min;

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -1,0 +1,135 @@
+use rand::distributions::uniform::SampleBorrow;
+use rand::distributions::uniform::SampleUniform;
+use rand::distributions::uniform::UniformInt;
+use rand::distributions::uniform::UniformSampler;
+use rand::distributions::Distribution;
+use rand::distributions::Standard;
+use rand::Rng;
+
+use crate::Duration;
+use crate::Time;
+
+impl Distribution<Time> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Time {
+        Time(rng.gen())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct UniformTime(UniformInt<i64>);
+
+impl UniformSampler for UniformTime {
+    type X = Time;
+
+    fn new<B1, B2>(low: B1, high: B2) -> Self
+    where
+        B1: SampleBorrow<Self::X> + Sized,
+        B2: SampleBorrow<Self::X> + Sized,
+    {
+        Self(UniformInt::new(low.borrow().0, high.borrow().0))
+    }
+
+    fn new_inclusive<B1, B2>(low: B1, high: B2) -> Self
+    where
+        B1: SampleBorrow<Self::X> + Sized,
+        B2: SampleBorrow<Self::X> + Sized,
+    {
+        Self(UniformInt::new_inclusive(low.borrow().0, high.borrow().0))
+    }
+
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+        Time(self.0.sample(rng))
+    }
+}
+
+impl SampleUniform for Time {
+    type Sampler = UniformTime;
+}
+
+impl Distribution<Duration> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Duration {
+        Duration(rng.gen())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct UniformDuration(UniformInt<i64>);
+
+impl UniformSampler for UniformDuration {
+    type X = Duration;
+
+    fn new<B1, B2>(low: B1, high: B2) -> Self
+    where
+        B1: SampleBorrow<Self::X> + Sized,
+        B2: SampleBorrow<Self::X> + Sized,
+    {
+        Self(UniformInt::new(low.borrow().0, high.borrow().0))
+    }
+
+    fn new_inclusive<B1, B2>(low: B1, high: B2) -> Self
+    where
+        B1: SampleBorrow<Self::X> + Sized,
+        B2: SampleBorrow<Self::X> + Sized,
+    {
+        Self(UniformInt::new_inclusive(low.borrow().0, high.borrow().0))
+    }
+
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+        Duration(self.0.sample(rng))
+    }
+}
+
+impl SampleUniform for Duration {
+    type Sampler = UniformDuration;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn standard_time() {
+        let _: Time = rand::random();
+        let _: Time = rand::thread_rng().gen();
+    }
+
+    #[test]
+    fn uniform_time() {
+        let mut rng = rand::thread_rng();
+        assert_eq!(Time::EPOCH, rng.gen_range(Time::EPOCH..Time::millis(1)));
+        assert_eq!(Time::EPOCH, rng.gen_range(Time::EPOCH..=Time::EPOCH));
+
+        let low = Time::millis(100);
+        let high = Time::millis(110);
+        for _ in 0..1000 {
+            let x = rng.gen_range(low..high);
+            assert!((low..high).contains(&x));
+        }
+    }
+
+    #[test]
+    fn standard_duration() {
+        let _: Duration = rand::random();
+        let _: Duration = rand::thread_rng().gen();
+    }
+
+    #[test]
+    fn uniform_duration() {
+        let mut rng = rand::thread_rng();
+        assert_eq!(
+            Duration::ZERO,
+            rng.gen_range(Duration::ZERO..Duration::millis(1))
+        );
+        assert_eq!(
+            Duration::ZERO,
+            rng.gen_range(Duration::ZERO..=Duration::ZERO)
+        );
+
+        let low = Duration::millis(100);
+        let high = Duration::millis(110);
+        for _ in 0..1000 {
+            let x = rng.gen_range(low..high);
+            assert!((low..high).contains(&x));
+        }
+    }
+}


### PR DESCRIPTION
Gated behind a new `rand` feature that's disabled by default to avoid the dependency on `rand`.