### PR TITLE
chore: update rand to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "bitflags"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,13 +107,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -187,7 +194,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -210,20 +217,20 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
+ "zerocopy 0.8.14",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -231,11 +238,12 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
  "getrandom",
+ "zerocopy 0.8.14",
 ]
 
 [[package]]
@@ -373,9 +381,12 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -506,13 +517,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468"
+dependencies = [
+ "zerocopy-derive 0.8.14",
 ]
 
 [[package]]
@@ -520,6 +549,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rand = ["dep:rand"]
 [dependencies]
 chrono = "0.4.39"
 derive_more = { version = "1.0.0", features = ["deref", "from", "into", "not", "sum"] }
-rand = { version = "0.8.5", optional = true }
+rand = { version = "0.9.0", optional = true }
 regex = "1.11.1"
 serde = { version = "1.0.217", features = ["derive"], default-features = false }
 thiserror = "2.0.11"

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -1,17 +1,17 @@
-use rand::distributions::uniform::SampleBorrow;
-use rand::distributions::uniform::SampleUniform;
-use rand::distributions::uniform::UniformInt;
-use rand::distributions::uniform::UniformSampler;
-use rand::distributions::Distribution;
-use rand::distributions::Standard;
+use rand::distr::uniform::SampleBorrow;
+use rand::distr::uniform::SampleUniform;
+use rand::distr::uniform::UniformInt;
+use rand::distr::uniform::UniformSampler;
+use rand::distr::Distribution;
+use rand::distr::StandardUniform;
 use rand::Rng;
 
 use crate::Duration;
 use crate::Time;
 
-impl Distribution<Time> for Standard {
+impl Distribution<Time> for StandardUniform {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Time {
-        Time(rng.gen())
+        Time(rng.random())
     }
 }
 
@@ -21,20 +21,20 @@ pub struct UniformTime(UniformInt<i64>);
 impl UniformSampler for UniformTime {
     type X = Time;
 
-    fn new<B1, B2>(low: B1, high: B2) -> Self
+    fn new<B1, B2>(low: B1, high: B2) -> Result<Self, rand::distr::uniform::Error>
     where
         B1: SampleBorrow<Self::X> + Sized,
         B2: SampleBorrow<Self::X> + Sized,
     {
-        Self(UniformInt::new(low.borrow().0, high.borrow().0))
+        UniformInt::new(low.borrow().0, high.borrow().0).map(Self)
     }
 
-    fn new_inclusive<B1, B2>(low: B1, high: B2) -> Self
+    fn new_inclusive<B1, B2>(low: B1, high: B2) -> Result<Self, rand::distr::uniform::Error>
     where
         B1: SampleBorrow<Self::X> + Sized,
         B2: SampleBorrow<Self::X> + Sized,
     {
-        Self(UniformInt::new_inclusive(low.borrow().0, high.borrow().0))
+        UniformInt::new_inclusive(low.borrow().0, high.borrow().0).map(Self)
     }
 
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
@@ -46,9 +46,9 @@ impl SampleUniform for Time {
     type Sampler = UniformTime;
 }
 
-impl Distribution<Duration> for Standard {
+impl Distribution<Duration> for StandardUniform {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Duration {
-        Duration(rng.gen())
+        Duration(rng.random())
     }
 }
 
@@ -58,20 +58,20 @@ pub struct UniformDuration(UniformInt<i64>);
 impl UniformSampler for UniformDuration {
     type X = Duration;
 
-    fn new<B1, B2>(low: B1, high: B2) -> Self
+    fn new<B1, B2>(low: B1, high: B2) -> Result<Self, rand::distr::uniform::Error>
     where
         B1: SampleBorrow<Self::X> + Sized,
         B2: SampleBorrow<Self::X> + Sized,
     {
-        Self(UniformInt::new(low.borrow().0, high.borrow().0))
+        UniformInt::new(low.borrow().0, high.borrow().0).map(Self)
     }
 
-    fn new_inclusive<B1, B2>(low: B1, high: B2) -> Self
+    fn new_inclusive<B1, B2>(low: B1, high: B2) -> Result<Self, rand::distr::uniform::Error>
     where
         B1: SampleBorrow<Self::X> + Sized,
         B2: SampleBorrow<Self::X> + Sized,
     {
-        Self(UniformInt::new_inclusive(low.borrow().0, high.borrow().0))
+        UniformInt::new_inclusive(low.borrow().0, high.borrow().0).map(Self)
     }
 
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
@@ -90,19 +90,19 @@ mod tests {
     #[test]
     fn standard_time() {
         let _: Time = rand::random();
-        let _: Time = rand::thread_rng().gen();
+        let _: Time = rand::rng().random();
     }
 
     #[test]
     fn uniform_time() {
-        let mut rng = rand::thread_rng();
-        assert_eq!(Time::EPOCH, rng.gen_range(Time::EPOCH..Time::millis(1)));
-        assert_eq!(Time::EPOCH, rng.gen_range(Time::EPOCH..=Time::EPOCH));
+        let mut rng = rand::rng();
+        assert_eq!(Time::EPOCH, rng.random_range(Time::EPOCH..Time::millis(1)));
+        assert_eq!(Time::EPOCH, rng.random_range(Time::EPOCH..=Time::EPOCH));
 
         let low = Time::millis(100);
         let high = Time::millis(110);
         for _ in 0..1000 {
-            let x = rng.gen_range(low..high);
+            let x = rng.random_range(low..high);
             assert!((low..high).contains(&x));
         }
     }
@@ -110,25 +110,25 @@ mod tests {
     #[test]
     fn standard_duration() {
         let _: Duration = rand::random();
-        let _: Duration = rand::thread_rng().gen();
+        let _: Duration = rand::rng().random();
     }
 
     #[test]
     fn uniform_duration() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         assert_eq!(
             Duration::ZERO,
-            rng.gen_range(Duration::ZERO..Duration::millis(1))
+            rng.random_range(Duration::ZERO..Duration::millis(1))
         );
         assert_eq!(
             Duration::ZERO,
-            rng.gen_range(Duration::ZERO..=Duration::ZERO)
+            rng.random_range(Duration::ZERO..=Duration::ZERO)
         );
 
         let low = Duration::millis(100);
         let high = Duration::millis(110);
         for _ in 0..1000 {
-            let x = rng.gen_range(low..high);
+            let x = rng.random_range(low..high);
             assert!((low..high).contains(&x));
         }
     }


### PR DESCRIPTION
Lots of breaking changes in the [new `rand` release](https://github.com/rust-random/rand/blob/master/rand_core/CHANGELOG.md).
