### PR TITLE
chore: Remove unnecessary dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,35 +218,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,7 +287,6 @@ version = "0.13.1"
 dependencies = [
  "chrono",
  "rand",
- "regex",
  "serde",
  "serde_json",
  "serde_test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,26 +320,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tinytime"
 version = "0.13.1"
 dependencies = [
@@ -349,7 +329,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,26 +86,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,7 +344,6 @@ name = "tinytime"
 version = "0.13.1"
 dependencies = [
  "chrono",
- "derive_more",
  "rand",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ rand = ["dep:rand"]
 [dependencies]
 chrono = "0.4.39"
 rand = { version = "0.9.0", optional = true }
-regex = "1.11.1"
 serde = { version = "1.0.217", features = ["derive"], default-features = false }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ rand = ["dep:rand"]
 
 [dependencies]
 chrono = "0.4.39"
-derive_more = { version = "1.0.0", features = ["deref", "from", "into", "not", "sum"] }
 rand = { version = "0.9.0", optional = true }
 regex = "1.11.1"
 serde = { version = "1.0.217", features = ["derive"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ chrono = "0.4.39"
 rand = { version = "0.9.0", optional = true }
 regex = "1.11.1"
 serde = { version = "1.0.217", features = ["derive"], default-features = false }
-thiserror = "2.0.11"
 
 [dev-dependencies]
 serde_test = "1.0.176"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,6 @@ use regex::Regex;
 use serde::de::Visitor;
 use serde::Deserialize;
 use serde::Serialize;
-use thiserror::Error;
 
 /// A point in time.
 ///
@@ -425,11 +424,21 @@ impl Debug for Time {
     }
 }
 
-#[derive(Error, Debug, Eq, PartialEq, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum TimeWindowError {
-    #[error("time window start is after end")]
     StartAfterEnd,
 }
+
+impl Display for TimeWindowError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::StartAfterEnd => "time window start is after end",
+        };
+        write!(f, "{message}")
+    }
+}
+
+impl Error for TimeWindowError {}
 
 /// An interval or range of time: `[start,end)`.
 /// Debug-asserts ensure that start <= end.


### PR DESCRIPTION
Removes the following dependencies, replacing them with manual implementations:

- `derive_more`
- `thiserror`
- `regex`