### PR TITLE
feat: Add optional bincode support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,13 @@ keywords = ["time", "tiny", "low-overhead"]
 categories = ["date-and-time"]
 
 [features]
+bincode = ["dep:bincode"]
+chrono = ["dep:chrono"]
 rand = ["dep:rand"]
 serde = ["dep:serde"]
-chrono = ["dep:chrono"]
 
 [dependencies]
+bincode = { version = "2.0.1", features = ["derive"], default-features = false, optional = true }
 chrono = { version = "0.4.40", features = ["alloc"], default-features = false, optional = true }
 rand = { version = "0.9.0", features = ["thread_rng"], default-features = false, optional = true }
 serde = { version = "1.0.219", features = ["derive"], default-features = false, optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ use std::time::SystemTime;
 /// Low overhead time representation. Internally represented as milliseconds.
 #[derive(Eq, PartialEq, Hash, Ord, PartialOrd, Copy, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(feature = "bincode", derive(::bincode::Encode, ::bincode::Decode))]
 pub struct Time(i64);
 
 impl Time {
@@ -324,6 +325,7 @@ impl Error for TimeWindowError {}
 /// correcting invalid use of the API (and setting end to start).
 #[derive(Clone, Debug, Eq, PartialEq, Default, Copy, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(feature = "bincode", derive(::bincode::Encode, ::bincode::Decode))]
 pub struct TimeWindow {
     start: Time,
     end: Time,
@@ -937,6 +939,7 @@ impl From<(Time, Time)> for TimeWindow {
 /// milliseconds.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(feature = "bincode", derive(::bincode::Encode, ::bincode::Decode))]
 pub struct Duration(i64);
 
 impl Duration {


### PR DESCRIPTION
Adds support for [bincode](docs.rs/bincode) encoding & decoding gated behind a new feature flag.

While bincode has a serde compatibility layer, it has [known issues](https://docs.rs/bincode/latest/bincode/serde/index.html#known-issues). With this, we provide native bincode support.
